### PR TITLE
Fix some issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+.vscode

--- a/index.js
+++ b/index.js
@@ -1,14 +1,7 @@
-process.argv.slice(2).reduce(function(base, arg) {
-  if(arg[0] === '-') {
-    base = module.exports[arg] || (module.exports[arg] = []);
+process.argv.slice(2).forEach(function(arg) {
+  if (arg.startsWith('-')) {
+    this.current = module.exports[arg] = [];
   } else {
-    [].push.call(base, arg);
+    this.current.push(arg);
   }
-  return base;
-}, module.exports = Object.create([], {
-  length: {
-    value: 0,
-    writable: true,
-    configurable: true
-  }
-}));
+}, { current: module.exports = [] });

--- a/tests/isarray.js
+++ b/tests/isarray.js
@@ -1,1 +1,1 @@
-console.log(JSON.stringify(require('../index.js') instanceof Array));
+console.log(Array.isArray(require('../index.js')));

--- a/tests/print.js
+++ b/tests/print.js
@@ -1,1 +1,34 @@
-console.log(JSON.stringify(require('../index.js')));
+if (!Object.assign) {
+  Object.defineProperty(Object, 'assign', {
+    enumerable: false,
+    configurable: true,
+    writable: true,
+    value: function(target) {
+      'use strict';
+      if (target === undefined || target === null) {
+        throw new TypeError('Cannot convert first argument to object');
+      }
+
+      var to = Object(target);
+      for (var i = 1; i < arguments.length; i++) {
+        var nextSource = arguments[i];
+        if (nextSource === undefined || nextSource === null) {
+          continue;
+        }
+        nextSource = Object(nextSource);
+
+        var keysArray = Object.keys(nextSource);
+        for (var nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex++) {
+          var nextKey = keysArray[nextIndex];
+          var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
+          if (desc !== undefined && desc.enumerable) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+      return to;
+    }
+  });
+}
+
+console.log(JSON.stringify(Object.assign({}, require('../index.js'))));


### PR DESCRIPTION
There are issues in the code:
-  The first parameter of `Object.create` should ( almost ) always be an function ( constructor )'s prototype, instead of its instance.That is to say: you should write `Object.create(Array.prototype)` instead of `Object.create([])`, they are different things.
  Object.create(Array.prototype): result => Array.prototype => Object.prototype => null
  Object.create([]): result => new Array() /*redundant */ => Array.prototype => Object.prototype => null
-  The result of

``` js
Object.create([] /* or Array.prototype */, {
  length: {
    value: 0,
    writable: true,
    configurable: true
  }
})
```

is not an Array; it's just an array like object. The test you wrote in `isarray.js`

``` js
something instanceof Array
```

Only checks whether its proto tree contains Array.prototype, which doesn't means it **is** an array, for example:

``` js
var instance = Object.create([] /* or Array.prototype */, {
  length: {
    value: 0,
    writable: true,
    configurable: true
  }
});
console.log(Array.isArray(instance)); // false
console.log(Object.prototype.toString.call(instance) === "[object Array]")); // false
console.log(JSON.stringify(instance) === '[]')); // false
```

In addition, it doesn't behave exactly the same as an array:

``` js
var instance1 = Object.create([] /* or Array.prototype */, {
  length: {
    value: 0,
    writable: true,
    configurable: true
  }
});
instance1.push(1, 2, 3);
instance1.length = 0;
console.log(instance1[0]); // 1
```

while

``` js
var instance2 = [1, 2, 3];
instance2.length = 0;
console.log(instance2[0]); // undefined
```
- Minor: the callback of `Array.prototype.reduce` should be pure, as its designed. Well, it's ok not to obey it. I just say it:)
# 

My PR fixes all issues mentioned above, also make the code more understandable.
Notable: I changed `tests/print.js` to make the test pass( it prints [ XXX ] otherwise )
